### PR TITLE
#17 支払い方法の抽出追加と請求書対応

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -115,7 +115,7 @@ AIの概要を置換するためのルール。
 
 ## Gemini 解析仕様
 ### レシート抽出プロンプト出力（`callGeminiApi`）
-JSON形式で以下を出力:
+JSON形式で以下を出力（JSONのみ・キー順固定）:
 ```
 {
   "paymentDate": "YYYY/MM/DD",
@@ -126,10 +126,10 @@ JSON形式で以下を出力:
   "amount": 12345
 }
 ```
-- paymentDate は支払日
+- paymentDate は支払日（請求書は支払日が不明なら発行日）
 - paymentMethod は上記の候補から選択（iD/QUICPay はクレカ扱い）
 - invoiceNumber は `T` + 13桁（無い場合は空文字）
-- amount は税込合計の整数（判読不能な場合は空）
+- amount は税込合計の整数（不明なら 0）
 
 ### マネフォ用プロンプト出力（`callGeminiApiForMoneyForward_`）
 JSON形式で以下を出力:


### PR DESCRIPTION
## Summary
- レシート/請求書の抽出に支払い方法を追加
- 解析結果シートに支払い方法列を挿入
- 支払い方法の正規化とプロンプト更新
- spec.md を更新

## Related Issue
Closes #17

## Changes
- 解析結果のヘッダー拡張と既存シートへの列追加
- 支払い方法の抽出・正規化（iD/QUICPayはクレカ扱い）
- レシート/領収書/請求書を対象にした抽出プロンプト
- 仕様ドキュメント更新

## Testing
- [ ] Manual check (未実施)
