### PR TITLE
#21 ヘルプを新規タブで開く

### DIFF
--- a/コード.js
+++ b/コード.js
@@ -2167,16 +2167,16 @@ function showImageSidebar() {
 function showHelp() {
   const htmlContent = `
     <html>
-      <body style="font-family: Arial, sans-serif; font-size: 13px;">
-        <p>ヘルプページを開きます。</p>
-        <p>
-          <a href="${HELP_URL}" target="_blank" rel="noopener">ヘルプを開く</a>
-        </p>
+      <body>
+        <script>
+          window.open(${JSON.stringify(HELP_URL)}, '_blank');
+          google.script.host.close();
+        </script>
       </body>
     </html>
   `;
   SpreadsheetApp.getUi().showModalDialog(
-    HtmlService.createHtmlOutput(htmlContent).setWidth(280).setHeight(140),
+    HtmlService.createHtmlOutput(htmlContent).setWidth(1).setHeight(1),
     'ヘルプ'
   );
 }


### PR DESCRIPTION
## Summary
- メニューの「ヘルプを見る」で新規タブを自動オープンするよう変更

## Related Issue
Closes #21

## Changes
- `showHelp()` を自動新規タブ + 即クローズ方式に変更

## Testing
- [ ] Unit tests
- [x] Manual check: メニュー操作で新規タブが開くことを確認
