### PR TITLE
#24 ヘルプをサイドバー表示に変更

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -44,7 +44,7 @@
 - `4. マネフォ用解析` → `analyzeMoneyForward`
 - `5. マネフォCSVダウンロード` → `downloadMoneyForwardCsv`
 - `画像プレビューを開く` → `showImageSidebar`
-- `ヘルプを見る` → `showHelp`（サイドバーでGitHub Pagesを表示／表示されない場合はリンク）
+- `ヘルプを見る` → `showHelp`（モーダルでGitHub Pagesを表示／表示されない場合はリンク）
 - サブメニュー `⚙️ 設定`
   - `APIキーの設定` → `setApiKey`
   - `モデル切替（現在: <model>）` → `setModelName`

--- a/コード.js
+++ b/コード.js
@@ -2165,12 +2165,14 @@ function showImageSidebar() {
 }
 
 function showHelp() {
-  const html = HtmlService.createHtmlOutput(buildHelpSidebarHtml_())
-    .setTitle('ヘルプ');
-  SpreadsheetApp.getUi().showSidebar(html);
+  const html = HtmlService.createHtmlOutput(buildHelpDialogHtml_())
+    .setTitle('ヘルプ')
+    .setWidth(1000)
+    .setHeight(900);
+  SpreadsheetApp.getUi().showModalDialog(html, 'ヘルプ');
 }
 
-function buildHelpSidebarHtml_() {
+function buildHelpDialogHtml_() {
   const helpUrl = HELP_URL;
   return `
 <!DOCTYPE html>
@@ -2178,8 +2180,10 @@ function buildHelpSidebarHtml_() {
   <head>
     <meta charset="utf-8">
     <style>
+      html,
       body {
         font-family: "Noto Sans JP", Arial, sans-serif;
+        height: 100%;
         margin: 0;
       }
       .header {
@@ -2197,7 +2201,7 @@ function buildHelpSidebarHtml_() {
         text-decoration: none;
       }
       .content {
-        height: calc(100vh - 64px);
+        height: calc(100% - 64px);
       }
       iframe {
         border: 0;


### PR DESCRIPTION
## Summary
- ヘルプをポップアップからサイドバー表示へ変更（iframe埋め込み）
- サイドバー上部に直接開けるリンクを追加

## Related Issue
Closes #24

## Changes
- `showHelp` をサイドバー表示に変更
- ヘルプ用HTMLを追加
- 仕様書のヘルプ表示説明を更新

## Testing
- [ ] Manual check: メニューから「ヘルプを見る」を実行してサイドバー表示を確認
