### PR TITLE
#28 画像プレビューをポップアップで拡大表示できるようにする

### DIFF
--- a/コード.js
+++ b/コード.js
@@ -2328,8 +2328,15 @@ function buildImageSidebarHtml_() {
   `;
 }
 
+function escapeJsonForInlineScript_(value) {
+  return JSON.stringify(value || {})
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}
+
 function buildImagePreviewDialogHtml_(initialInfo) {
-  const initialDataJson = JSON.stringify(initialInfo || {});
+  const initialDataJson = escapeJsonForInlineScript_(initialInfo);
   return `
     <html>
       <head>
@@ -2379,7 +2386,6 @@ function buildImagePreviewDialogHtml_(initialInfo) {
             document.getElementById('thumb').src = data.thumbnailUrl || '';
           }
           render(initialData);
-          refresh();
           setInterval(refresh, 3000);
         </script>
       </body>


### PR DESCRIPTION
## Summary
- 画像プレビューサイドバーに「拡大表示」ボタンを追加
- ボタン押下でモデルレスダイアログ（900x650）を開き、大きなプレビューを表示
- ダイアログ表示中も3秒ごとに選択行を再取得してプレビューを自動更新

## Related Issue
Closes #28

## Changes
- `コード.js`
  - `showImagePreviewDialog` を追加（モデルレスダイアログ表示）
  - `buildImageSidebarHtml_` に「拡大表示」ボタンを追加し、未選択時の無効化制御を実装
  - `buildImagePreviewDialogHtml_` を追加し、更新/閉じる操作と自動更新ロジックを実装

## Testing
- [x] Unit tests
  - `node` + `vm` で HTML ビルダー関数を実行し、必要な要素（拡大表示ボタン/自動更新/閉じる処理）の存在を確認
- [ ] Manual check: スプレッドシート上でサイドバーから拡大表示、閉じる、選択行変更時の追従、画像/PDF表示を確認
- [x] GAS sync: `npx clasp push`
