### PR TITLE
#30 貸方が事業主借のとき貸方税区分を対象外にする

### DIFF
--- a/コード.js
+++ b/コード.js
@@ -2005,6 +2005,9 @@ function buildMoneyForwardRow_(transactionNo, data, partnerName, fileUrl, settin
     data.paymentMethod === 'クレカ'
       ? (settings?.creditAccountCard || '未払金')
       : (settings?.creditAccountOther || '役員借入金');
+  const creditTaxCategory = normalizeText_(creditAccount) === '事業主借'
+    ? '対象外'
+    : taxCategory;
   const creditSubAccount =
     data.paymentMethod === 'クレカ'
       ? resolveCreditSubAccount_(settings, data)
@@ -2025,7 +2028,7 @@ function buildMoneyForwardRow_(transactionNo, data, partnerName, fileUrl, settin
     creditSubAccount,
     '',
     '',
-    taxCategory,
+    creditTaxCategory,
     '',
     amount,
     0,


### PR DESCRIPTION
## Summary
- マネフォ用シート転記時、貸方勘定科目が「事業主借」の場合に貸方税区分を「対象外」へ上書き

## Related Issue
Closes #30

## Changes
- `コード.js`
  - `buildMoneyForwardRow_` で `creditAccount === '事業主借'` の場合のみ、貸方税区分（`MF_CSV_HEADERS` の「貸方税区分」）を `対象外` に設定

## Testing
- [x] 構文チェック: `node --check コード.js`
- [x] 簡易確認: Node(vm)で `buildMoneyForwardRow_` の貸方税区分が `対象外` になることを確認
- [ ] Manual check: 設定で貸方勘定科目(それ以外)=事業主借 の行を作成し、マネフォ用シートの貸方税区分が対象外になることを確認
- [x] GAS sync: `npx clasp push`
